### PR TITLE
Upgrade website to English engineering portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,41 +3,135 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Γρηγόρης Ζολώτας - Μηχανολόγος Μηχανικός</title>
+    <meta name="description" content="Grigoris Zolotas is a mechanical engineer and product design specialist focused on 3D CAD, mechanical design, prototyping, and engineering problem solving.">
+    <title>Grigoris Zolotas | Mechanical Engineer & Product Designer</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <header>
-        <h1>ΓΡΗΓΟΡΗΣ ΖΟΛΩΤΑΣ</h1>
-        <p>ΜΗΧΑΝΟΛΟΓΟΣ ΜΗΧΑΝΙΚΟΣ | ΣΧΕΔΙΑΣΤΗΣ ΠΡΟΪΟΝΤΩΝ</p>
-        <nav>
-            <a href="index.html">Home</a>
-            <a href="portfolio.html">Portfolio</a>
-            <a href="contact.html">Contact</a>
+    <header class="hero" id="home">
+        <nav class="navbar" aria-label="Main navigation">
+            <a class="logo" href="#home">GZ</a>
+            <div class="nav-links">
+                <a href="#services">Services</a>
+                <a href="#experience">Experience</a>
+                <a href="#projects">Projects</a>
+                <a href="#contact">Contact</a>
+            </div>
         </nav>
+
+        <div class="hero-grid">
+            <div class="hero-copy">
+                <p class="eyebrow">Mechanical Engineer · Product Design · CAD Automation</p>
+                <h1>Engineering ideas into practical, manufacturable products.</h1>
+                <p class="hero-text">I help turn concepts, technical requirements, and production problems into clean 3D models, drawings, prototypes, and reliable mechanical solutions.</p>
+                <div class="hero-actions">
+                    <a class="button primary" href="#contact">Start a project</a>
+                    <a class="button secondary" href="Grigoris%20Zolotas.pdf" download>Download CV</a>
+                </div>
+            </div>
+
+            <aside class="profile-card" aria-label="Profile summary">
+                <img src="grigoris.jpg" alt="Grigoris Zolotas" class="profile-img">
+                <h2>Grigoris Zolotas</h2>
+                <p>Mechanical Engineer focused on mechanical design, 3D CAD, prototyping, and design optimization.</p>
+                <a href="mailto:gregory.zol.123@hotmail.com">gregory.zol.123@hotmail.com</a>
+            </aside>
+        </div>
     </header>
 
-    <section class="content">
-        <img src="grigoris.jpg" alt="Grigoris Zolotas" class="profile-img">
+    <main>
+        <section class="section" id="services">
+            <div class="section-heading">
+                <p class="eyebrow">What I do</p>
+                <h2>Engineering support for real-world products</h2>
+            </div>
+            <div class="cards three-columns">
+                <article class="card">
+                    <h3>Mechanical Design</h3>
+                    <p>3D CAD modelling, assemblies, technical drawings, design reviews, and manufacturability improvements.</p>
+                </article>
+                <article class="card">
+                    <h3>Product Development</h3>
+                    <p>From early concepts to functional prototypes using rapid prototyping, iteration, and practical engineering judgement.</p>
+                </article>
+                <article class="card">
+                    <h3>Workflow Automation</h3>
+                    <p>Support for CAD/BOM workflows, Excel automation, data cleanup, and engineering process improvements.</p>
+                </article>
+            </div>
+        </section>
 
-        
-        <h2>About Me</h2>
-        <p>Μηχανολόγος μηχανικός με εξειδίκευση στον μηχανολογικό σχεδιασμό (2D/3D) και τη βελτιστοποίηση σχεδιασμού. Με ενθουσιάζει το να φέρνω καινοτόμες ιδέες σε φυσική μορφή χρησιμοποιώντας τον συνδυασμό μεθόδων ταχείας πρωτοτυποποίησης και αυτοματισμών.  </p>
+        <section class="section split" id="experience">
+            <div>
+                <p class="eyebrow">Experience</p>
+                <h2>Mechanical design experience in industrial environments</h2>
+                <p>I have worked on mechanical design, product improvement, and technical documentation for manufacturing-focused companies.</p>
+            </div>
+            <div class="timeline">
+                <article>
+                    <h3>E.V.A.K. S.A.</h3>
+                    <p>Design Engineer — mechanical design, product development, CAD work, and engineering documentation.</p>
+                </article>
+                <article>
+                    <h3>V. Kyparissis & Co.</h3>
+                    <p>Mechanical Engineer — engineering support, technical design tasks, and practical product development experience.</p>
+                </article>
+                <article>
+                    <h3>V. Kyparissis & Co.</h3>
+                    <p>Internship — first hands-on engineering experience in a professional mechanical design environment.</p>
+                </article>
+            </div>
+        </section>
 
-        <h2>Work Experience</h2>
-        <div class="work-boxes">
-            <a href="ebak.html" class="work-box">🔹 Ε.Β.Α.Κ A.E. (Μηχανικός Σχεδίασης)</a>
-            <a href="kyparissis.html" class="work-box">🔹 Β. ΚΥΠΑΡΙΣΣΗΣ & ΣΙΑ ΕΤΕ (Μηχανολόγος Μηχανικός)</a>
-            <a href="intern.html" class="work-box">🔹 Β. ΚΥΠΑΡΙΣΣΗΣ & ΣΙΑ ΕΤΕ (Πρακτική)</a>
-        </div>
+        <section class="section dark" id="projects">
+            <div class="section-heading">
+                <p class="eyebrow">Focus areas</p>
+                <h2>Built around practical engineering and problem solving</h2>
+            </div>
+            <div class="cards three-columns">
+                <article class="card dark-card">
+                    <h3>CAD & Technical Drawings</h3>
+                    <p>Clear, structured models and drawings that support production, communication, and future design changes.</p>
+                </article>
+                <article class="card dark-card">
+                    <h3>3D Printing & Prototyping</h3>
+                    <p>Fast physical validation of ideas, fit checks, custom components, and iterative product improvement.</p>
+                </article>
+                <article class="card dark-card">
+                    <h3>Automation & Electronics</h3>
+                    <p>Practical experimentation with Arduino, control systems, sensors, and small automation projects.</p>
+                </article>
+            </div>
+        </section>
 
-        <h2>Λήψη Βιογραφικού</h2>
-        <p>📄 <a href="Grigoris%20Zolotas.pdf" download>Κλικ για λήψη βιογραφικού (PDF)</a></p>
-    </section>
+        <section class="section contact-section" id="contact">
+            <div>
+                <p class="eyebrow">Contact</p>
+                <h2>Have a product, part, or engineering problem?</h2>
+                <p>Send me a short message with what you need. I can help with mechanical design, CAD work, prototyping, and technical problem solving.</p>
+            </div>
 
-    <footer>
-        <p>📩 Contact me at <a href="mailto:gregory.zol.123@hotmail.com">gregory.zol.123@hotmail.com</a></p>
-        <p>© 2025 Grigoris Zolotas | Mechanical Engineer</p>
+            <form class="contact-form" action="https://formspree.io/f/xovjndza" method="POST">
+                <label for="name">Name</label>
+                <input type="text" id="name" name="name" placeholder="Your name" required>
+
+                <label for="email">Email</label>
+                <input type="email" id="email" name="email" placeholder="your@email.com" required>
+
+                <label for="subject">Subject</label>
+                <input type="text" id="subject" name="subject" placeholder="Project or question" required>
+
+                <label for="message">Message</label>
+                <textarea id="message" name="message" rows="5" placeholder="Tell me what you need..." required></textarea>
+
+                <button class="button primary" type="submit">Send message</button>
+            </form>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <p>© 2026 Grigoris Zolotas · Mechanical Engineer</p>
+        <p><a href="mailto:gregory.zol.123@hotmail.com">gregory.zol.123@hotmail.com</a></p>
     </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
             <div class="nav-links">
                 <a href="#services">Services</a>
                 <a href="#experience">Experience</a>
-                <a href="#projects">Projects</a>
+                <a href="#selected-projects">Projects</a>
                 <a href="#contact">Contact</a>
             </div>
         </nav>
@@ -79,6 +79,94 @@
                 <article>
                     <h3>V. Kyparissis & Co.</h3>
                     <p>Internship — first hands-on engineering experience in a professional mechanical design environment.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="section projects-section" id="selected-projects">
+            <div class="section-heading">
+                <p class="eyebrow">Selected projects</p>
+                <h2>Practical work across CAD, prototyping, automation, and engineering studies</h2>
+                <p>These project cards are prepared as placeholders. Real images, screenshots, and final case-study text can be added later without changing the site structure.</p>
+            </div>
+
+            <div class="project-grid">
+                <article class="project-card">
+                    <div class="project-visual">CAD</div>
+                    <div class="project-content">
+                        <span class="project-tag">Mechanical Design</span>
+                        <h3>CAD Assembly & Production Drawings</h3>
+                        <p>3D modelling, assembly structure, drawing preparation, and design-for-manufacturing support for mechanical components.</p>
+                        <ul>
+                            <li>Tools: Solid Edge, technical drawings</li>
+                            <li>Focus: manufacturability, clarity, revision control</li>
+                        </ul>
+                    </div>
+                </article>
+
+                <article class="project-card">
+                    <div class="project-visual">AGRI</div>
+                    <div class="project-content">
+                        <span class="project-tag">Agricultural Machinery</span>
+                        <h3>Machinery Component Development</h3>
+                        <p>Mechanical design work connected to robust, production-ready equipment used in demanding agricultural environments.</p>
+                        <ul>
+                            <li>Focus: durability, practical assembly, serviceability</li>
+                            <li>Images can be added after confidential details are removed</li>
+                        </ul>
+                    </div>
+                </article>
+
+                <article class="project-card">
+                    <div class="project-visual">3D</div>
+                    <div class="project-content">
+                        <span class="project-tag">Prototyping</span>
+                        <h3>3D Printed Functional Prototypes</h3>
+                        <p>Fast iteration of custom brackets, adapters, fixtures, and proof-of-concept parts using CAD and desktop 3D printing.</p>
+                        <ul>
+                            <li>Tools: CAD, slicing software, FDM printing</li>
+                            <li>Focus: fit checks, low-cost validation, quick improvement</li>
+                        </ul>
+                    </div>
+                </article>
+
+                <article class="project-card">
+                    <div class="project-visual">BOM</div>
+                    <div class="project-content">
+                        <span class="project-tag">CAD / ERP Workflow</span>
+                        <h3>BOM Matching & Engineering Data Cleanup</h3>
+                        <p>Workflow concepts for connecting CAD bill-of-material data with ERP item codes using structured Excel processing and matching logic.</p>
+                        <ul>
+                            <li>Tools: Excel, VBA, BOM exports</li>
+                            <li>Focus: fewer manual errors, faster item identification</li>
+                        </ul>
+                    </div>
+                </article>
+
+                <article class="project-card">
+                    <div class="project-visual">PID</div>
+                    <div class="project-content">
+                        <span class="project-tag">Electronics & Control</span>
+                        <h3>Arduino-Based Boost Control Experiment</h3>
+                        <p>Experimental control-system project using pressure sensing, PWM solenoid control, filtering, and PID tuning logic.</p>
+                        <ul>
+                            <li>Tools: Arduino, sensors, MOSFET driver, PID control</li>
+                            <li>Focus: diagnostics, control stability, practical electronics</li>
+                        </ul>
+                    </div>
+                </article>
+
+                <article class="project-card">
+                    <div class="project-visual">GAS</div>
+                    <div class="project-content">
+                        <span class="project-tag">Engineering Studies</span>
+                        <h3>Residential Natural Gas Study Support</h3>
+                        <p>Engineering service area prepared for future local SEO and client-facing pages related to residential gas installation studies.</p>
+                        <ul>
+                            <li>Focus: residential clients, technical documentation</li>
+                            <li>Future page: local service landing page</li>
+                        </ul>
+                    </div>
                 </article>
             </div>
         </section>

--- a/styles.css
+++ b/styles.css
@@ -1,27 +1,404 @@
+:root {
+    --bg: #0f172a;
+    --bg-soft: #111827;
+    --panel: #ffffff;
+    --panel-soft: #f8fafc;
+    --text: #0f172a;
+    --muted: #64748b;
+    --muted-light: #cbd5e1;
+    --accent: #2563eb;
+    --accent-dark: #1d4ed8;
+    --accent-soft: #dbeafe;
+    --line: #e2e8f0;
+    --shadow: 0 24px 70px rgba(15, 23, 42, 0.18);
+    --radius: 24px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
 body {
-    font-family: Arial, sans-serif;
-    text-align: center;
     margin: 0;
-    padding: 0;
-    background-color: #f4f4f4;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: #f8fafc;
+    color: var(--text);
+    line-height: 1.6;
 }
 
-header {
-    background: #0073e6;
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.hero {
+    min-height: 92vh;
+    padding: 28px clamp(20px, 5vw, 72px) 80px;
+    background:
+        radial-gradient(circle at top left, rgba(37, 99, 235, 0.45), transparent 34%),
+        linear-gradient(135deg, #020617 0%, #0f172a 52%, #1e3a8a 100%);
+    color: #ffffff;
+    overflow: hidden;
+}
+
+.navbar {
+    max-width: 1180px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+}
+
+.logo {
+    width: 48px;
+    height: 48px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    font-weight: 800;
+    letter-spacing: 0.06em;
+}
+
+.nav-links {
+    display: flex;
+    gap: 22px;
+    color: var(--muted-light);
+    font-size: 0.95rem;
+}
+
+.nav-links a:hover {
+    color: #ffffff;
+}
+
+.hero-grid {
+    max-width: 1180px;
+    margin: 90px auto 0;
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+    gap: 56px;
+    align-items: center;
+}
+
+.eyebrow {
+    margin: 0 0 14px;
+    color: #60a5fa;
+    font-size: 0.8rem;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.hero h1 {
+    margin: 0;
+    max-width: 820px;
+    font-size: clamp(2.7rem, 7vw, 5.8rem);
+    line-height: 0.95;
+    letter-spacing: -0.06em;
+}
+
+.hero-text {
+    max-width: 650px;
+    margin: 26px 0 0;
+    color: #dbeafe;
+    font-size: clamp(1.05rem, 2vw, 1.28rem);
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    margin-top: 34px;
+}
+
+.button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 48px;
+    padding: 0 22px;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    font-weight: 800;
+    cursor: pointer;
+    transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+.button:hover {
+    transform: translateY(-2px);
+}
+
+.button.primary {
+    background: var(--accent);
     color: white;
-    padding: 20px;
+    box-shadow: 0 16px 36px rgba(37, 99, 235, 0.35);
 }
 
-.content {
-    margin: 20px;
-    padding: 20px;
+.button.primary:hover {
+    background: var(--accent-dark);
+}
+
+.button.secondary {
+    border-color: rgba(255, 255, 255, 0.22);
+    color: white;
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.profile-card {
+    background: rgba(255, 255, 255, 0.11);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    backdrop-filter: blur(18px);
+    border-radius: var(--radius);
+    padding: 28px;
+    box-shadow: var(--shadow);
+}
+
+.profile-img {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    object-fit: cover;
+    border-radius: 22px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    margin-bottom: 22px;
+}
+
+.profile-card h2 {
+    margin: 0 0 8px;
+    font-size: 1.45rem;
+}
+
+.profile-card p {
+    color: #dbeafe;
+    margin: 0 0 18px;
+}
+
+.profile-card a {
+    color: #bfdbfe;
+    font-weight: 700;
+    word-break: break-word;
+}
+
+.section {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 92px clamp(20px, 4vw, 32px);
+}
+
+.section-heading {
+    max-width: 760px;
+    margin-bottom: 34px;
+}
+
+.section h2 {
+    margin: 0;
+    font-size: clamp(2rem, 4vw, 3.25rem);
+    line-height: 1.05;
+    letter-spacing: -0.04em;
+}
+
+.section p {
+    color: var(--muted);
+}
+
+.cards {
+    display: grid;
+    gap: 22px;
+}
+
+.three-columns {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.card {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 28px;
+    box-shadow: 0 14px 40px rgba(15, 23, 42, 0.06);
+}
+
+.card h3 {
+    margin: 0 0 12px;
+    font-size: 1.25rem;
+}
+
+.card p {
+    margin: 0;
+}
+
+.split {
+    display: grid;
+    grid-template-columns: 0.8fr 1.2fr;
+    gap: 54px;
+    align-items: start;
+}
+
+.timeline {
+    display: grid;
+    gap: 16px;
+}
+
+.timeline article {
+    position: relative;
+    padding: 24px 24px 24px 28px;
     background: white;
-    border-radius: 5px;
+    border: 1px solid var(--line);
+    border-radius: 20px;
+    box-shadow: 0 10px 34px rgba(15, 23, 42, 0.05);
 }
 
-footer {
-    margin-top: 20px;
-    padding: 10px;
-    background: #333;
+.timeline article::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 24px;
+    bottom: 24px;
+    width: 4px;
+    border-radius: 999px;
+    background: var(--accent);
+}
+
+.timeline h3 {
+    margin: 0 0 8px;
+}
+
+.timeline p {
+    margin: 0;
+}
+
+.dark {
+    max-width: none;
+    background: var(--bg);
     color: white;
+    padding-left: max(clamp(20px, 4vw, 32px), calc((100vw - 1180px) / 2 + 32px));
+    padding-right: max(clamp(20px, 4vw, 32px), calc((100vw - 1180px) / 2 + 32px));
+}
+
+.dark .section-heading,
+.dark .cards {
+    max-width: 1180px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.dark p {
+    color: var(--muted-light);
+}
+
+.dark-card {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.12);
+    box-shadow: none;
+}
+
+.contact-section {
+    display: grid;
+    grid-template-columns: 0.9fr 1.1fr;
+    gap: 42px;
+    align-items: start;
+}
+
+.contact-form {
+    background: white;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 28px;
+    box-shadow: var(--shadow);
+    display: grid;
+    gap: 12px;
+}
+
+.contact-form label {
+    font-weight: 800;
+    font-size: 0.92rem;
+}
+
+.contact-form input,
+.contact-form textarea {
+    width: 100%;
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    padding: 14px 16px;
+    font: inherit;
+    color: var(--text);
+    background: var(--panel-soft);
+}
+
+.contact-form input:focus,
+.contact-form textarea:focus {
+    outline: 3px solid var(--accent-soft);
+    border-color: var(--accent);
+}
+
+.contact-form button {
+    margin-top: 8px;
+    border: 0;
+    font: inherit;
+}
+
+.footer {
+    display: flex;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 28px clamp(20px, 5vw, 72px);
+    background: #020617;
+    color: var(--muted-light);
+}
+
+.footer a {
+    color: white;
+    font-weight: 700;
+}
+
+@media (max-width: 900px) {
+    .hero-grid,
+    .split,
+    .contact-section {
+        grid-template-columns: 1fr;
+    }
+
+    .three-columns {
+        grid-template-columns: 1fr;
+    }
+
+    .hero-grid {
+        margin-top: 60px;
+    }
+
+    .profile-card {
+        max-width: 440px;
+    }
+}
+
+@media (max-width: 640px) {
+    .hero {
+        padding-top: 20px;
+    }
+
+    .navbar {
+        align-items: flex-start;
+    }
+
+    .nav-links {
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 10px 14px;
+        font-size: 0.88rem;
+    }
+
+    .section {
+        padding-top: 68px;
+        padding-bottom: 68px;
+    }
+
+    .footer {
+        flex-direction: column;
+    }
 }


### PR DESCRIPTION
This PR keeps the current live website on main untouched while introducing a levelled-up English version of the site.

Changes included:
- Full English homepage rewrite
- Modern landing-page structure
- Improved visual design and responsive CSS
- Services, experience, focus areas, and contact sections
- Selected Projects section with placeholder project cards
- Existing Formspree contact form preserved

Review this branch before merging. Merging this PR will publish the upgraded version to the live GitHub Pages site.